### PR TITLE
Replace deprecated (php7.4) curly braces 

### DIFF
--- a/includes/date.php
+++ b/includes/date.php
@@ -26,7 +26,7 @@ class ZDateHelper {
 	 *
 	 * @param int $year is between 1 and 32767 inclusive
 	 *
-	 * @return int 
+	 * @return int
 	 */
 	static function DayInMonth($month, $year) {
 	   $daysInMonth = array(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31);
@@ -198,7 +198,7 @@ class ZDateHelper {
 	 * Format iCal date-time string to Unix timestamp
 	 *
 	 * @param string $datetime in iCal time format ( YYYYMMDD or YYYYMMDDTHHMMSS or YYYYMMDDTHHMMSSZ )
-	 * 
+	 *
 	 * @return int Unix timestamp
 	 */
 	static function fromiCaltoUnixDateTime($datetime) {
@@ -222,7 +222,7 @@ class ZDateHelper {
 			$hour = 0;
 			$minute = 0;
 			$second = 0;
-			if(strlen($datetime) > 8 && $datetime{8} == "T") {
+			if(strlen($datetime) > 8 && $datetime[8] == "T") {
 				$hour = substr($datetime,9,2);
 				$minute = substr($datetime,11,2);
 				$second = substr($datetime,13,2);
@@ -244,20 +244,20 @@ class ZDateHelper {
 
 	/**
 	 * Convert iCal duration string to # of seconds
-	 * 
+	 *
 	 * @param string $duration iCal duration string
 	 *
-	 * return int 
+	 * return int
 	 */
 	static function iCalDurationtoSeconds($duration) {
 		$secs = 0;
-		if($duration{0} == "P") {
+		if($duration[0] == "P") {
 			$duration = str_replace(array("H","M","S","T","D","W","P"),array("H,","M,","S,","","D,","W,",""),$duration);
 			$dur2 = explode(",",$duration);
 			foreach($dur2 as $dur){
 				$val=intval($dur);
 				if(strlen($dur) > 0){
-					switch($dur{strlen($dur) - 1}) {
+					switch($dur[strlen($dur) - 1]) {
 						case "H":
 							$secs += 60*60 * $val;
 							break;
@@ -300,7 +300,7 @@ class ZDateHelper {
 		$dayend = self::addDate($daystart, 0,0,0,0,1,0);
 
 		$end = max($begin, $end); // $end can't be less than $begin
-		$inday = 
+		$inday =
 			($daystart <= $begin && $begin < $dayend)
 			||($daystart < $end && $end < $dayend)
 			||($begin <= $daystart && $end > $dayend)
@@ -357,13 +357,13 @@ class ZDateHelper {
 	 * @param int $hour add or subtract hours from date
 	 *
 	 * @param int $min add or subtract minutes from date
-	 * 
+	 *
 	 * @param int $sec add or subtract seconds from date
-	 * 
+	 *
 	 * @param int $month add or subtract months from date
-	 * 
+	 *
 	 * @param int $day add or subtract days from date
-	 * 
+	 *
 	 * @param int $year add or subtract years from date
 	 *
 	 * @param string $tzid PHP recognized timezone (default is UTC)
@@ -427,7 +427,7 @@ class ZDateHelper {
 
 	/**
 	 * Convert UTC date-time to local date-time
-	 * 
+	 *
 	 * @param string $sqldate SQL date-time string
 	 *
 	 * @param string $tzid PHP recognized timezone (default is "UTC")
@@ -452,7 +452,7 @@ class ZDateHelper {
 
 	/**
 	 * Convert local date-time to UTC date-time
-	 * 
+	 *
 	 * @param string $sqldate SQL date-time string
 	 *
 	 * @param string $tzid PHP recognized timezone (default is "UTC")
@@ -484,7 +484,7 @@ class ZDateHelper {
 	 *
 	 * Examples of relative dates are "-2y" for 2 years ago, "18m"
 	 * for 18 months after today. Relative date uses "y", "m" and "d" for
-	 * year, month and day. Relative date can be combined into comma 
+	 * year, month and day. Relative date can be combined into comma
 	 * separated list, i.e., "-1y,-1d" for 1 year and 1 day ago.
 	 *
 	 * @param string $date relative date string (i.e. "1y" for 1 year from today)

--- a/includes/ical.php
+++ b/includes/ical.php
@@ -35,7 +35,7 @@ class ZCiCalDataNode {
 
 	/**
 	 * Node values (after the colon ":")
-	 * 
+	 *
 	 * @var array
 	 */
 	var $value=array();
@@ -60,7 +60,7 @@ class ZCiCalDataNode {
 		$inquotes = false;
 		while(!$datafind && ($i < strlen($tline))) {
 			//echo "$i: " . $tline{$i} . ", ord() = " . ord($tline{$i}) . "<br>\n";
-			if(!$inquotes && $tline{$i} == ':')
+			if(!$inquotes && $tline[$i] == ':')
 				$datafind=true;
 			else{
 				$i += 1;
@@ -113,7 +113,7 @@ class ZCiCalDataNode {
 /**
  * Get $ith parameter from array
  * @param int $i
- * 
+ *
  * @return var
  */
 	function getParameter($i){
@@ -131,7 +131,7 @@ class ZCiCalDataNode {
 
 /**
  * Get comma separated values
- * 
+ *
  * @return string
  */
 	function getValues(){
@@ -350,7 +350,7 @@ class ZCiCalNode {
 	 * export tree to icalendar format
 	 *
 	 * @param object $node Top level node to export
-	 * 
+	 *
 	 * @param int $level Level of recursion (usually leave this blank)
 	 *
 	 * @return string iCalendar formatted output
@@ -436,7 +436,7 @@ class ZCiCalNode {
 	function printDataLine($d, $p)
 	{
 		$txtstr = "";
-	
+
 		$values = $d->getValues();
 		// don't think we need this, Sunbird does not like it in the EXDATE field
 		//$values = str_replace(",", "\\,", $values);
@@ -473,7 +473,7 @@ class ZCiCal {
 	 */
 	var $tree=null;
 	/**
-	 * The most recently created  node in the tree 
+	 * The most recently created  node in the tree
 	 *
 	 * @var object
 	 */
@@ -838,7 +838,7 @@ function toUnixDateTime($datetime){
 	$hour = 0;
 	$minute = 0;
 	$second = 0;
-	if(strlen($datetime) > 8 && $datetime{8} == "T") {
+	if(strlen($datetime) > 8 && $datetime[8] == "T") {
 		$hour = substr($datetime,9,2);
 		$minute = substr($datetime,11,2);
 		$second = substr($datetime,13,2);
@@ -849,7 +849,7 @@ function toUnixDateTime($datetime){
 
 /**
  * fromUnixDateTime()
- * 
+ *
  * Take Unix timestamp and format to iCal date/time string
  *
  * @param int $datetime Unix timestamp, leave blank for current date/time
@@ -868,7 +868,7 @@ static function fromUnixDateTime($datetime = null){
 
 /**
  * fromUnixDate()
- * 
+ *
  * Take Unix timestamp and format to iCal date string
  *
  * @param int $datetime Unix timestamp, leave blank for current date/time
@@ -886,7 +886,7 @@ static function fromUnixDate($datetime = null){
 
 /**
  * Format into iCal time format from SQL date or SQL date-time format
- * 
+ *
  * @param string $datetime SQL date or SQL date-time string
  *
  * @return string iCal formatted string
@@ -904,7 +904,7 @@ static function fromSqlDateTime($datetime = ""){
 
 /**
  * Format iCal time format to either SQL date or SQL date-time format
- * 
+ *
  * @param string $datetime icalendar formatted date or date-time
  * @return string SQL date or SQL date-time string
  * @deprecated Use ZDateHelper::toSqlDateTime() instead

--- a/includes/recurringdate.php
+++ b/includes/recurringdate.php
@@ -733,7 +733,6 @@ class ZCRecurringDate {
 			$eventcount += $count;
 			if($maxdate > 0 && $maxdate < $nextdate)
 			{
-				array_pop($rdates);
 				$done = true;
 			}
 			else if($count == 0 && !$this->maxDates($rdates)){

--- a/includes/recurringdate.php
+++ b/includes/recurringdate.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * recurringdate.php - create list of dates from recurring rule
- * 
+ *
  * @package	ZapCalLib
  * @author	Dan Cogliano <http://zcontent.net>
  * @copyright   Copyright (C) 2006 - 2017 by Dan Cogliano
@@ -62,7 +62,7 @@ class ZCRecurringDate {
 
 	/**
 	 * repeat count when repeat mode is 'c'
-	 * 
+	 *
 	 * @var integer
 	 */
 	var $count=0;
@@ -150,7 +150,7 @@ class ZCRecurringDate {
 	 * @var array
 	 */
 	var $exdates=array();
-	
+
 /**
  * Expand recurring rule to a list of dates
  *
@@ -166,7 +166,7 @@ class ZCRecurringDate {
 			{
 				$exdates[$i] = ZDateHelper::toUnixDateTime(ZDateHelper::toLocalDateTime(ZDateHelper::toSQLDateTime($exdates[$i]),$tzid));
 			}
-	
+
 			$rules=str_replace("\'","",$rules);
 			$this->rules = $rules;
 			if($startdate == null){
@@ -177,7 +177,7 @@ class ZCRecurringDate {
 			$this->startdate = $startdate;
 			$this->tzid = $tzid;
 			$this->exdates = $exdates;
-	
+
 			$rules=explode(";", $rules);
 			$ruletype = "";
 			foreach($rules as $rule){
@@ -280,7 +280,7 @@ class ZCRecurringDate {
 			}
 		}
 	}
-	
+
 /**
  * bysetpos rule support
  *
@@ -303,11 +303,11 @@ class ZCRecurringDate {
  * save error
  *
  * @param string $msg
- */	
+ */
 	function setError($msg){
 		$this->error = $msg;
 	}
-	
+
 /**
  * get error message
  *
@@ -338,10 +338,10 @@ class ZCRecurringDate {
 		if($this->debug >= $level)
 			echo $msg . "<br/>\n";
 	}
-	
+
 /**
  * Get repeating dates by year
- * 
+ *
  * @param integer $startdate start date of repeating events, in Unix timestamp format
  * @param integer $enddate end date of repeating events, in Unix timestamp format
  * @param array $rdates array to contain expanded repeating dates
@@ -371,10 +371,10 @@ class ZCRecurringDate {
 		self::debug(1,"byYear() returned " . $count );
 		return $count;
 	}
-	
+
 /**
  * Get repeating dates by month
- * 
+ *
  * @param integer $startdate start date of repeating events, in Unix timestamp format
  * @param integer $enddate end date of repeating events, in Unix timestamp format
  * @param array $rdates array to contain expanded repeating dates
@@ -407,7 +407,7 @@ class ZCRecurringDate {
 
 /**
  * Get repeating dates by month day
- * 
+ *
  * @param integer $startdate start date of repeating events, in Unix timestamp format
  * @param integer $enddate end date of repeating events, in Unix timestamp format
  * @param array $rdates array to contain expanded repeating dates
@@ -443,10 +443,10 @@ class ZCRecurringDate {
 		self::debug(1,"byMonthDay() returned " . $count );
 		return $count;
 	}
-	
+
 /**
  * Get repeating dates by day
- * 
+ *
  * @param integer $startdate start date of repeating events, in Unix timestamp format
  * @param integer $enddate end date of repeating events, in Unix timestamp format
  * @param array $rdates array to contain expanded repeating dates
@@ -473,7 +473,7 @@ class ZCRecurringDate {
 			4 => "TH",
 			5 => "FR",
 			6 => "SA");
-	
+
 		$count = 0;
 		if(count($this->byday) > 0){
 			if(empty($this->byday[0]))
@@ -537,7 +537,7 @@ class ZCRecurringDate {
 
 /**
  * Get repeating dates by hour
- * 
+ *
  * @param integer $startdate start date of repeating events, in Unix timestamp format
  * @param integer $enddate end date of repeating events, in Unix timestamp format
  * @param array $rdates array to contain expanded repeating dates
@@ -571,7 +571,7 @@ class ZCRecurringDate {
 
 /**
  * Get repeating dates by minute
- * 
+ *
  * @param integer $startdate start date of repeating events, in Unix timestamp format
  * @param integer $enddate end date of repeating events, in Unix timestamp format
  * @param array $rdates array to contain expanded repeating dates
@@ -603,7 +603,7 @@ class ZCRecurringDate {
 	}
 /**
  * Get repeating dates by second
- * 
+ *
  * @param integer $startdate start date of repeating events, in Unix timestamp format
  * @param integer $enddate end date of repeating events, in Unix timestamp format
  * @param array $rdates array to contain expanded repeating dates
@@ -631,11 +631,11 @@ class ZCRecurringDate {
 
 /**
  * Determine if the loop has reached the end date
- * 
+ *
  * @param array $rdates array of repeating dates
  *
  * @return boolean
- */	
+ */
 	private function maxDates($rdates){
 		if($this->repeatmode == "c" && count($rdates) >= $this->count)
 			return true; // exceeded count
@@ -651,7 +651,7 @@ class ZCRecurringDate {
  * @param $maxdate integer maximum date to appear in repeating dates in Unix timestamp format
  *
  * @return array
- */	
+ */
 	public function getDates($maxdate = null){
 		//$this->debug = 2;
 		self::debug(1,"getDates()");
@@ -680,7 +680,7 @@ class ZCRecurringDate {
 			case "m":
 				if($eventcount > 0)
 				{
-					
+
 					$nextdate = ZDateHelper::addDate($nextdate,0,0,0,$this->interval,0,0,$this->tzid);
 					self::debug(2,"addDate() returned " . ZDateHelper::toSqlDateTime($nextdate));
 				}
@@ -728,7 +728,7 @@ class ZCRecurringDate {
 				$enddate=ZDateHelper::addDate($nextdate,0,0,0,0,1,0);
 				break;
 			}
-	
+
 			$count = $this->byYear($nextdate,$enddate,$rdates,$this->tzid);
 			$eventcount += $count;
 			if($maxdate > 0 && $maxdate < $nextdate)
@@ -742,7 +742,7 @@ class ZCRecurringDate {
 			}
 			if($this->maxDates($rdates))
 				$done = true;
-	
+
 			$year = date("Y", $nextdate);
 			if($year > _ZAPCAL_MAXYEAR)
 			{
@@ -763,7 +763,7 @@ class ZCRecurringDate {
 		$count2 = count($rdates);
 		$dups = $count1 - $count2;
 		$excount = 0;
-	
+
 		foreach($this->exdates as $exdate)
 		{
 			if($pos = array_search($exdate,$rdates))
@@ -773,15 +773,15 @@ class ZCRecurringDate {
 			}
 		}
 		self::debug(1,"getDates() returned " . count($rdates) . " dates, removing $dups duplicates, $excount exceptions");
-	
-	
+
+
 		if($this->debug >= 2)
 		{
 			self::debug(2,"Recurring Dates:");
 			foreach($rdates as $rdate)
 			{
 				$d = getdate($rdate);
-				self::debug(2,ZDateHelper::toSQLDateTime($rdate) . " " . $d["wday"] ); 
+				self::debug(2,ZDateHelper::toSQLDateTime($rdate) . " " . $d["wday"] );
 			}
 			self::debug(2,"Exception Dates:");
 			foreach($this->exdates as $exdate)
@@ -790,7 +790,7 @@ class ZCRecurringDate {
 			}
 			//exit;
 		}
-	
+
 		return $rdates;
 	}
 }


### PR DESCRIPTION
Since php 7.4 curly braces method to get individual characters inside a string has been deprecated