### PR TITLE
Multiple ATTENDEE value duplicates the second

### DIFF
--- a/includes/ical.php
+++ b/includes/ical.php
@@ -261,8 +261,7 @@ class ZCiCalNode {
 		{
 			if(!is_array($this->data[$node->getName()]))
 			{
-				$this->data[$node->getName()] = array();
-				$this->data[$node->getName()][] = $node;
+				$this->data[$node->getName()] = array($this->data[$node->getName()]);
 			}
 			$this->data[$node->getName()][] = $node;
 		}


### PR DESCRIPTION
When I try to put multiple attendees

```PHP
require_once("zapcallib.php");

$icalobj = new ZCiCal();

$eventobj = new ZCiCalNode("VEVENT", $icalobj->curnode);

$eventobj->addNode(new ZCiCalDataNode("ATTENDEE;CN=abc@xyz.com:mailto:abc@xyz.com"));
$eventobj->addNode(new ZCiCalDataNode("ATTENDEE;CN=abcd@xyz.com:mailto:abcd@xyz.com"));
$eventobj->addNode(new ZCiCalDataNode("ATTENDEE;CN=abcde@xyz.com:mailto:abcde@xyz.com"));
echo $icalobj->export();
```

**Before Fix :**

> BEGIN:VCALENDAR
> VERSION:2.0
> PRODID:-//ZContent.net//ZapCalLib 1.0//EN
> CALSCALE:GREGORIAN
> METHOD:PUBLISH
> BEGIN:VEVENT
> ATTENDEE;CN=abcd@xyz.com:mailto:abcd@xyz.com
> ATTENDEE;CN=abcd@xyz.com:mailto:abcd@xyz.com
> ATTENDEE;CN=abcde@xyz.com:mailto:abcde@xyz.com
> END:VEVENT
> END:VCALENDAR

**After Fix :** 

> BEGIN:VCALENDAR
> VERSION:2.0
> PRODID:-//ZContent.net//ZapCalLib 1.0//EN
> CALSCALE:GREGORIAN
> METHOD:PUBLISH
> BEGIN:VEVENT
> ATTENDEE;CN=abc@xyz.com:mailto:abc@xyz.com
> ATTENDEE;CN=abcd@xyz.com:mailto:abcd@xyz.com
> ATTENDEE;CN=abcde@xyz.com:mailto:abcde@xyz.com
> END:VEVENT
> END:VCALENDAR

Thanks