### PR TITLE
Fixing PHP 7.4 incompatible use of curly braces.

### DIFF
--- a/includes/date.php
+++ b/includes/date.php
@@ -257,7 +257,7 @@ class ZDateHelper {
 			foreach($dur2 as $dur){
 				$val=intval($dur);
 				if(strlen($dur) > 0){
-					switch($dur{strlen($dur) - 1}) {
+					switch($dur[strlen($dur) - 1]) {
 						case "H":
 							$secs += 60*60 * $val;
 							break;

--- a/includes/ical.php
+++ b/includes/ical.php
@@ -59,7 +59,7 @@ class ZCiCalDataNode {
 		$datafind = false;
 		$inquotes = false;
 		while(!$datafind && ($i < strlen($tline))) {
-			//echo "$i: " . $tline[$i] . ", ord() = " . ord($tline{$i}) . "<br>\n";
+			//echo "$i: " . $tline[$i] . ", ord() = " . ord($tline[$i]) . "<br>\n";
 			if(!$inquotes && $tline[$i] == ':')
 				$datafind=true;
 			else{


### PR DESCRIPTION
Missed a couple instances of string index using curly braces.