### PR TITLE
Also handle \;

### DIFF
--- a/includes/ical.php
+++ b/includes/ical.php
@@ -503,7 +503,7 @@ function __construct($data = "", $maxevents = 1000000, $startevent = 0) {
 		//$data = str_replace(array("\n ", "\n	"),"!?", $data);
 		$data = str_replace(array("\n ", "\n	"),"", $data);
 		// replace special iCal chars
-		$data = str_replace(array("\\\\","\,"),array("\\",","), $data);
+		$data = str_replace(array("\\\\","\,","\;"),array("\\",",",";"), $data);
 
 		// parse each line
 		$lines = explode("\n", $data);


### PR DESCRIPTION
..looks like this was forgotten. The other two escape chars are correctly handled.

Without this PR an event with the title `RFC5545 escape chars: \ ; ,` will be read from the iCalendar file as `RFC5545 escape chars: \ \; ,`.

See [iCalendar RFC](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.11) for escape char documentation.